### PR TITLE
feat(event-stream): implement retry mechanism for message consumption.

### DIFF
--- a/contract/EventStream/StreamInterface.php
+++ b/contract/EventStream/StreamInterface.php
@@ -42,6 +42,18 @@ interface StreamInterface
     public function subscribe(string $consumer, string $group, array $streams): Generator;
 
     /**
+     * Retrieves messages that have been idle for a specified duration within particular streams of a consumer group.
+     *
+     * @param  string  $consumer  The name of the consumer requesting the idle messages.
+     * @param  string  $group  The name of the consumer group.
+     * @param  array  $streams  An array of stream names to fetch idle messages from.
+     * @param  int  $retryAfter  The idle time in milliseconds after which messages are considered for retrieval.
+     *
+     * @return Generator<StreamMessage> Yields messages that meet the idle time criteria.
+     */
+    public function getIdleMessages(string $consumer, string $group, array $streams, int $retryAfter): Generator;
+
+    /**
      * Acknowledges one or more messages in the given stream and group.
      *
      * @param  string  $group  The name of the consumer group.

--- a/contract/EventStream/StreamMessage.php
+++ b/contract/EventStream/StreamMessage.php
@@ -25,6 +25,6 @@ class StreamMessage
 
     public function withContext(array $context): static
     {
-        return new static($this->stream, $this->type, $this->data, [...$this->context, ...$context]);
+        return new static($this->stream, $this->type, $this->data, [...$this->context, ...$context], $this->id);
     }
 }

--- a/event-stream/README.md
+++ b/event-stream/README.md
@@ -54,6 +54,7 @@ return [
     'consumer' => [
         'processes' => [], // Array of process configurations for different streams
         'block_for' => 1, // The number of seconds to sleep between processing batches
+        'retry_after' => 60, // The number of seconds to retry zombie message due to offline consumer or failed process
     ],
 
     // Serialization configuration for messages
@@ -141,7 +142,7 @@ namespace App\Event;
 
 use Menumbing\EventStream\Annotation\ConsumedEvent;
 
-#[ConsumedEvent(stream: 'user-events', name: 'user.created', driver: 'default')]
+#[ConsumedEvent(stream: 'user-events', name: 'user.created', driver: 'default', retries: 0)]
 class ConsumeUserCreated
 {
     public function __construct(
@@ -152,7 +153,7 @@ class ConsumeUserCreated
     }
 }
 ```
-It will automatically create a consumer process for each stream. Alternatively, you can configure consumers in the `event_stream.php` configuration file:
+It will automatically create a consumer process for each stream. The option `retries` indicate how many attempt should consumer process the message until it fire `ConsumeFailed` event. Alternatively, you can configure consumers in the `event_stream.php` configuration file:
 
 ```php
 'consumer' => [
@@ -160,6 +161,7 @@ It will automatically create a consumer process for each stream. Alternatively, 
         'user-events' => 2, // This will create 2 processes for 'user-events' stream
     ],
     'block_for' => 1, // The number of seconds to sleep between processing batches of messages.
+    'retry_after' => 30, // The number of seconds to retry zombie message due to offline consumer or failed process.
 ],
 ```
 

--- a/event-stream/publish/event_stream.php
+++ b/event-stream/publish/event_stream.php
@@ -42,15 +42,19 @@ return [
      *
      * Options:
      * - processes: Array of process configurations for different streams.
-     *   Each key represents a stream identifier with the value being the number of processes.
-     *   Example: ['stream1' => 2] will create 2 processes for 'stream1'
+     * Each key represents a stream identifier with the value being the number of processes.
+     * Example: ['stream1' => 2] will create 2 processes for 'stream1'
      *
      * - block_for: The number of seconds to sleep between processing batches of messages.
-     *   This helps control the consumption rate and system resources.
+     * This helps control the consumption rate and system resources.
+     *
+     * - retry_after: Time in seconds after which pending messages are considered
+     *               for reprocessing if not acknowledged
      */
     'consumer' => [
         'processes' => [],
         'block_for' => 1,
+        'retry_after' => 60,
     ],
 
     /**

--- a/event-stream/src/Annotation/ConsumedEvent.php
+++ b/event-stream/src/Annotation/ConsumedEvent.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace Menumbing\EventStream\Annotation;
 
 use Attribute;
+use Hyperf\Di\Annotation\AbstractAnnotation;
 
 /**
  * @author  Iqbal Maulana <iq.bluejack@gmail.com>
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-class ConsumedEvent extends ProducedEvent
+class ConsumedEvent extends AbstractAnnotation
 {
+    public function __construct(
+        public readonly string $stream,
+        public readonly string $name,
+        public readonly string $driver = 'default',
+        public readonly int $retries = 0,
+    ) {
+    }
 }

--- a/event-stream/src/Enum/Result.php
+++ b/event-stream/src/Enum/Result.php
@@ -10,4 +10,5 @@ namespace Menumbing\EventStream\Enum;
 enum Result
 {
     case ACK;
+    case NACK;
 }

--- a/event-stream/src/EventRegistry.php
+++ b/event-stream/src/EventRegistry.php
@@ -30,11 +30,14 @@ class EventRegistry
                 throw new EventNameConflictedException($name);
             }
 
-            $this->events[$name] = $class;
+            $this->events[$name] = [
+                'class' => $class,
+                'retries' => $annotation->retries,
+            ];
         }
     }
 
-    public function getClassByName(string $name): string
+    public function getClassByName(string $name): array
     {
         if (!$this->has($name)) {
             throw new EventNotFoundException(sprintf('Event "%s" not found.', $name));

--- a/event-stream/src/Listener/DebugListener.php
+++ b/event-stream/src/Listener/DebugListener.php
@@ -81,9 +81,10 @@ final class DebugListener implements ListenerInterface
     {
         if ($event instanceof ConsumeEvent) {
             $this->logger->debug(
-                message: '[{timestamp}] Event Stream {type} event {message_id} from stream {stream_name} on group {group_name} with driver {driver_name}',
+                message: '[{timestamp}] Event Stream attempt {attempt} {type} event {message_id} from stream {stream_name} on group {group_name} with driver {driver_name}',
                 context: [
                     'timestamp' => date('Y-m-d H:i:s'),
+                    'attempt' => $event->message->context['retry_count'] ?? 0,
                     'type' => $type,
                     'message_id' => $event->message->id,
                     'stream_name' => $event->message->stream,


### PR DESCRIPTION
Added support for message retries with configurable limits and idle message handling using `retry_after`. Introduced `NACK` result type, updated event dispatch logic, and enhanced configuration options for stream consumers. Updated annotations, documentation, and message processing to reflect these changes.