### PR TITLE
feat(outbox): add outbox pattern package for event-stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,15 @@
             "Menumbing\\Tracer\\": "tracer/src",
             "Menumbing\\GraphQL\\": "graphql/src",
             "Menumbing\\OAuth2\\ResourceServer\\": "oauth2-resource-server/src",
-            "Menumbing\\GracefulProcess\\": "graceful-process/src"
+            "Menumbing\\GracefulProcess\\": "graceful-process/src",
+            "Menumbing\\EventStream\\": "event-stream/src",
+            "Menumbing\\Serializer\\": "serializer/src",
+            "Menumbing\\Outbox\\": "outbox/src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "HyperfTest\\": "outbox/tests/"
         }
     },
     "authors": [

--- a/contract/Outbox/OutboxRecord.php
+++ b/contract/Outbox/OutboxRecord.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Contract\Outbox;
+
+use Menumbing\Contract\EventStream\StreamMessage;
+
+/**
+ * A read-only representation of an outbox message returned by the storage.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class OutboxRecord
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly StreamMessage $message,
+        public readonly OutboxStatus $status,
+        public readonly int $retryCount,
+        public readonly ?string $lastError = null,
+        public readonly ?string $sentAt = null,
+        public readonly ?string $failedAt = null,
+    ) {
+    }
+}

--- a/contract/Outbox/OutboxStatus.php
+++ b/contract/Outbox/OutboxStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Contract\Outbox;
+
+/**
+ * Represents the lifecycle state of an outbox message.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+enum OutboxStatus: string
+{
+    /** The message is waiting to be relayed to the stream. */
+    case PENDING = 'pending';
+
+    /** The message failed at least once but will be retried. */
+    case FAILED = 'failed';
+
+    /** The message has been successfully relayed to the stream. */
+    case SENT = 'sent';
+
+    /** The message exceeded the maximum retry count and will no longer be retried. */
+    case DEAD_LETTER = 'dead_letter';
+}

--- a/contract/Outbox/OutboxStorageInterface.php
+++ b/contract/Outbox/OutboxStorageInterface.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Contract\Outbox;
+
+use Generator;
+use Menumbing\Contract\EventStream\StreamMessage;
+use Throwable;
+
+/**
+ * Abstraction for storing and retrieving outbox messages.
+ *
+ * Implementations MUST ensure that {@see store()} participates in the
+ * currently active database transaction so the outbox record commits
+ * atomically with the business data.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+interface OutboxStorageInterface
+{
+    /**
+     * Persist a stream message to the outbox.
+     *
+     * This method is expected to run within the caller's database
+     * transaction. If the transaction rolls back the outbox record
+     * MUST be rolled back as well.
+     *
+     * @param  StreamMessage  $message  The message to store.
+     *
+     * @return string The generated outbox record ID.
+     */
+    public function store(StreamMessage $message): string;
+
+    /**
+     * Retrieve messages that are ready for relay.
+     *
+     * Returns messages whose status is PENDING or FAILED, excluding
+     * FAILED messages that were last attempted within the retry window.
+     *
+     * When $forUpdate is true, the implementation SHOULD lock the selected
+     * rows (e.g., FOR UPDATE SKIP LOCKED) to prevent concurrent workers
+     * from processing the same messages. The caller MUST wrap the call
+     * in {@see transaction()} when $forUpdate is true so that the locks
+     * are held until the status updates are committed.
+     *
+     * @param  int   $limit       Maximum number of messages to return.
+     * @param  int   $retryAfter   Minimum seconds to wait before retrying a
+     *                            failed message. Zero means no delay.
+     * @param  bool  $forUpdate   Whether to lock the rows for update.
+     *
+     * @return Generator<OutboxRecord>
+     */
+    public function findPending(int $limit, int $retryAfter = 0, bool $forUpdate = false): Generator;
+
+    /**
+     * Execute the given callback within a storage transaction.
+     *
+     * When using FOR UPDATE locking in {@see findPending()}, this method
+     * MUST be used to wrap the query and subsequent status updates so
+     * that the locks are held until the transaction commits.
+     *
+     * @param  callable  $callback
+     */
+    public function transaction(callable $callback): void;
+
+    /**
+     * Mark a message as successfully relayed to the stream.
+     *
+     * @param  string  $id  The outbox record ID.
+     */
+    public function markAsSent(string $id): void;
+
+    /**
+     * Mark a message as failed.
+     *
+     * Increments the retry count and records the error. If the retry
+     * count reaches the configured maximum the message SHOULD be
+     * transitioned to DEAD_LETTER status.
+     *
+     * @param  string     $id     The outbox record ID.
+     * @param  Throwable  $error  The exception that caused the failure.
+     */
+    public function markAsFailed(string $id, Throwable $error): void;
+
+    /**
+     * Count messages that are currently awaiting relay.
+     *
+     * @return int
+     */
+    public function countPending(): int;
+
+    /**
+     * Delete sent messages older than the given retention period.
+     *
+     * Messages with status SENT and sent_at older than the cutoff
+     * are permanently deleted. This is intended for periodic cleanup
+     * via a scheduled command, not by the relay worker.
+     *
+     * @param  int  $retentionDays  Number of days to retain sent messages.
+     *
+     * @return int The number of deleted messages.
+     */
+    public function prune(int $retentionDays): int;
+}

--- a/event-stream/src/Listener/RegisterProducers.php
+++ b/event-stream/src/Listener/RegisterProducers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Menumbing\EventStream\Listener;
 
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Contract\ContainerInterface;
 use Hyperf\Di\Annotation\AnnotationCollector;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Event\ListenerProvider;
@@ -12,7 +14,6 @@ use Hyperf\Server\Event\MainCoroutineServerStart;
 use Menumbing\EventStream\Annotation\ProducedEvent;
 use Menumbing\EventStream\Factory\StreamFactory;
 use Menumbing\EventStream\Handler\ProduceEventHandler;
-use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
@@ -38,11 +39,29 @@ final class RegisterProducers implements ListenerInterface
         $listenerProvider = $this->container->get(ListenerProviderInterface::class);
         $streamFactory = $this->container->get(StreamFactory::class);
         $eventDispatcher = $this->container->get(EventDispatcherInterface::class);
+        $config = $this->container->get(ConfigInterface::class);
+
+        // The produce handler is configurable to support the outbox pattern.
+        // When the outbox package is installed, it sets 'produce_handler' in
+        // its own config (outbox.php). We check outbox config first, then
+        // fall back to event_stream config, then to the default handler.
+        $handlerClass = $config->has('outbox.produce_handler')
+            ? $config->get('outbox.produce_handler')
+            : $config->get('event_stream.produce_handler', ProduceEventHandler::class);
 
         if ($listenerProvider instanceof ListenerProvider) {
             foreach ($this->getAnnotations() as $class => $annotation) {
                 $driver = $streamFactory->get($annotation->driver);
-                $listenerProvider->on($class, new ProduceEventHandler($driver, $annotation, $eventDispatcher), -999999999);
+
+                // Use make() so handler subclasses with #[Inject] properties (e.g.
+                // OutboxProduceEventHandler) are resolved through the container.
+                $handler = $this->container->make($handlerClass, [
+                    $driver,
+                    $annotation,
+                    $eventDispatcher,
+                ]);
+
+                $listenerProvider->on($class, $handler, -999999999);
             }
         }
     }

--- a/outbox/.gitattributes
+++ b/outbox/.gitattributes
@@ -1,0 +1,2 @@
+/tests export-ignore
+/.github export-ignore

--- a/outbox/.gitignore
+++ b/outbox/.gitignore
@@ -1,0 +1,5 @@
+/.idea
+/vendor/
+composer.lock
+*.cache
+*.log

--- a/outbox/LICENSE
+++ b/outbox/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Hyperf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/outbox/README.md
+++ b/outbox/README.md
@@ -1,0 +1,314 @@
+# Outbox Pattern for Hyperf
+
+A transactional outbox pattern implementation for Hyperf applications using the [menumbing/event-stream](../event-stream) component.
+
+## The Problem
+
+When publishing events to a stream (Redis/Kafka) from within a database transaction, you face the **dual-write problem**:
+
+- If the DB commits but the stream publish fails → **event is lost**
+- If the stream publish succeeds but the DB rolls back → **phantom event** delivered to consumers
+
+## The Solution
+
+The outbox pattern solves this by writing the event to an `outbox_messages` database table **in the same transaction** as the business data. A background worker process then relays the stored messages to the actual stream driver.
+
+```
+Application (within DB transaction)          Worker Process (background)
+
+  Repository::save()                           loop:
+    → BEGIN TRANSACTION                          → BEGIN TRANSACTION
+    → model.push()                               → SELECT ... FOR UPDATE SKIP LOCKED
+    → domain event dispatched                    → for each record:
+      → OutboxProduceEventHandler                      → stream->publish(message)
+        → OutboxStorage::store()                       → markAsSent() or
+    → COMMIT                                         → markAsFailed()
+                                               → COMMIT
+                                               → sleep(interval)
+```
+
+This guarantees:
+- **Atomicity** — the outbox record commits or rolls back with the business data
+- **At-least-once delivery** — the worker retries until success or dead-letter
+- **Decoupling** — the application never blocks on stream availability
+
+## Installation
+
+```bash
+composer require menumbing/outbox
+```
+
+## Requirements
+
+- PHP >= 8.1
+- Hyperf Framework >= 3.1
+- menumbing/event-stream >= 1.0
+- menumbing/orm >= 1.0
+
+## Configuration
+
+Publish the configuration and migration files:
+
+```bash
+php bin/hyperf.php vendor:publish menumbing/outbox
+```
+
+This creates:
+- `config/autoload/outbox.php` — the outbox configuration
+- `migrations/2024_01_01_000000_create_outbox_messages_table.php` — the database migration
+
+Run the migration:
+
+```bash
+php bin/hyperf.php migrate
+```
+
+### Configuration Options
+
+```php
+// config/autoload/outbox.php
+
+return [
+    // The produce handler class used by event-stream's RegisterProducers.
+    // Set to OutboxProduceEventHandler::class to route event publishing
+    // through the outbox. Set to ProduceEventHandler::class to disable.
+    'produce_handler' => OutboxProduceEventHandler::class,
+
+    // Outbox storage configuration.
+    'storage' => [
+        'class'      => DatabaseOutboxStorage::class,
+        'connection' => 'default',       // DB connection (must match your ORM connection)
+        'table'      => 'outbox_messages',
+    ],
+
+    // Worker (relay) process configuration.
+    'worker' => [
+        'enabled'        => true,       // Set to false to disable the worker
+        'nums'           => 1,          // Number of worker processes
+        'batch_size'     => 100,       // Messages per poll cycle
+        'interval'       => 2,         // Seconds between poll cycles
+        'max_retries'    => 5,          // Retries before dead-lettering
+        'retry_after'    => 60,         // Seconds before retrying a failed message
+    ],
+
+    // Pruning configuration.
+    'prune' => [
+        'retention_days' => 7,          // Delete sent messages older than N days
+    ],
+];
+```
+
+## Usage
+
+### Producing Events
+
+Producing events works exactly the same as with `menumbing/event-stream`. Annotate your event class with `#[ProducedEvent]` and dispatch it via the event dispatcher:
+
+```php
+<?php
+
+namespace App\Event;
+
+use Menumbing\EventStream\Annotation\ProducedEvent;
+
+#[ProducedEvent(stream: 'user-events', name: 'user.created', driver: 'default')]
+class UserCreated
+{
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $username,
+        public readonly string $email
+    ) {
+    }
+}
+```
+
+```php
+<?php
+
+use App\Event\UserCreated;
+use Hyperf\Di\Annotation\Inject;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+class UserController
+{
+    #[Inject]
+    protected EventDispatcherInterface $eventDispatcher;
+
+    public function create(): void
+    {
+        // ... create user logic ...
+
+        // Dispatch event — it will be stored in the outbox table
+        // (within the current DB transaction) instead of being
+        // published directly to Redis/Kafka.
+        $this->eventDispatcher->dispatch(new UserCreated($userId, $username, $email));
+    }
+}
+```
+
+When the outbox is enabled, the event is stored in `outbox_messages` instead of being published directly to the stream. The worker process will relay it to the actual stream driver asynchronously.
+
+### Consuming Events
+
+Consuming events works exactly the same as with `menumbing/event-stream`. Create a consumer event class annotated with `#[ConsumedEvent]` and a listener for it. See the [event-stream documentation](../event-stream/README.md) for details.
+
+## How It Works
+
+### 1. Event Storage (within DB transaction)
+
+When an event annotated with `#[ProducedEvent]` is dispatched, the `OutboxProduceEventHandler` intercepts it. Instead of calling `StreamInterface::publish()`, it calls `OutboxStorageInterface::store()`, which inserts a row into the `outbox_messages` table.
+
+Because the storage uses the same database connection as the ORM, the INSERT participates in the active database transaction (started by the ORM's `EnableDatabaseTransaction` middleware). If the transaction commits, the outbox record commits. If it rolls back, the outbox record is rolled back — no phantom events.
+
+### 2. Event Relay (worker process)
+
+The `OutboxRelayProcess` runs as a Hyperf custom process. Each polling cycle runs within a **storage transaction** to ensure safe concurrent processing:
+
+1. **SELECT ... FOR UPDATE SKIP LOCKED** — locks pending rows, skipping any already locked by other workers. This allows multiple worker processes (`nums > 1`) to run concurrently without processing the same messages.
+2. **Publish** — each locked message is published to the actual `StreamInterface` (Redis/Kafka).
+3. **Update status** — within the same transaction:
+   - **Success** → status set to `sent`, `OutboxRelayed` event dispatched
+   - **Failure** → retry count incremented, `OutboxRelayFailed` event dispatched
+   - **Max retries exceeded** → status set to `dead_letter`, `OutboxDeadLettered` event dispatched
+4. **COMMIT** — releases all row locks.
+5. **Sleep** — waits for `interval` seconds before the next cycle, avoiding constant database polling.
+
+Failed messages are retried after the configured `retry_after` delay (in seconds).
+
+> **Note:** `FOR UPDATE SKIP LOCKED` requires MySQL 8.0+ or PostgreSQL 9.5+.
+
+### 3. Message Lifecycle
+
+| Status | Description |
+|---|---|
+| `pending` | Initial state — waiting to be relayed |
+| `failed` | Relay failed at least once — will be retried after delay |
+| `sent` | Successfully relayed to the stream |
+| `dead_letter` | Exceeded max retries — requires manual intervention |
+
+## Monitoring
+
+The `OutboxMessage` model is provided for querying the outbox table:
+
+```php
+use Menumbing\Outbox\Model\OutboxMessage;
+
+// Count pending messages
+$count = OutboxMessage::query()
+    ->whereIn('status', ['pending', 'failed'])
+    ->count();
+
+// Find dead-lettered messages
+$deadLettered = OutboxMessage::query()
+    ->where('status', 'dead_letter')
+    ->get();
+
+// Re-queue a dead-lettered message
+$deadLettered->first()->update(['status' => 'pending', 'retry_count' => 0]);
+```
+
+## Pruning
+
+Sent messages are retained for auditing but should be pruned periodically to prevent unbounded table growth. The `outbox:prune` command deletes sent messages older than the configured retention period:
+
+```bash
+# Use the configured retention_days (default: 7)
+php bin/hyperf.php outbox:prune
+
+# Override retention for this run only
+php bin/hyperf.php outbox:prune --days=30
+```
+
+### Cron Setup
+
+Add to your server's crontab:
+
+```bash
+# Prune sent outbox messages daily at 3 AM
+0 3 * * * cd /path/to/project && php bin/hyperf.php outbox:prune
+```
+
+### Configuration
+
+```php
+// config/autoload/outbox.php
+'prune' => [
+    'retention_days' => 7,  // delete messages older than 7 days
+],
+```
+
+> **Note:** Only messages with `status = sent` are pruned. Pending, failed, and dead-lettered messages are never affected.
+
+## Events
+
+The worker dispatches the following events. You can create listeners for monitoring, alerting, or custom retry logic:
+
+| Event | When | Payload |
+|---|---|---|
+| `OutboxRelayed` | Message successfully relayed to stream | `OutboxRecord` |
+| `OutboxRelayFailed` | Relay failed but will be retried | `OutboxRecord`, `Throwable` |
+| `OutboxDeadLettered` | Message exceeded max retries | `OutboxRecord`, `Throwable` |
+
+```php
+<?php
+
+namespace App\Listener;
+
+use Hyperf\Event\Annotation\Listener;
+use Hyperf\Event\Contract\ListenerInterface;
+use Menumbing\Outbox\Event\OutboxDeadLettered;
+
+#[Listener]
+class AlertDeadLetteredMessages implements ListenerInterface
+{
+    public function listen(): array
+    {
+        return [OutboxDeadLettered::class];
+    }
+
+    public function process(object $event): void
+    {
+        if ($event instanceof OutboxDeadLettered) {
+            // Send alert, log, or trigger manual review
+            // $event->record->id
+            // $event->record->message->stream
+            // $event->throwable->getMessage()
+        }
+    }
+}
+```
+
+## Custom Storage Implementation
+
+You can implement a custom storage (e.g., Redis-backed) by implementing `Menumbing\Contract\Outbox\OutboxStorageInterface` and configuring it:
+
+```php
+// config/autoload/outbox.php
+'storage' => [
+    'class' => App\Storage\RedisOutboxStorage::class,
+    // ...
+],
+```
+
+## Backward Compatibility
+
+The outbox package integrates with `menumbing/event-stream` via a small, backward-compatible change to `RegisterProducers`:
+
+- The handler class is resolved via `Container::make()` (instead of `new`) so that subclasses using `#[Inject]` (e.g. `OutboxProduceEventHandler`) are properly wired through the DI container. This has no effect on the default `ProduceEventHandler`, which has no injected dependencies.
+- The handler class is resolved from config with fallback: `outbox.produce_handler` → `event_stream.produce_handler` → `ProduceEventHandler::class`.
+
+As a result:
+
+- When the outbox package is **not installed**, event-stream uses the default `ProduceEventHandler` (publishes directly to the stream)
+- When installed, `outbox.produce_handler` is set to `OutboxProduceEventHandler::class` by default — events are routed through the outbox
+- To disable the outbox and revert to direct publishing:
+
+```php
+// config/autoload/outbox.php
+'produce_handler' => \Menumbing\EventStream\Handler\ProduceEventHandler::class,
+```
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/outbox/composer.json
+++ b/outbox/composer.json
@@ -1,0 +1,70 @@
+{
+    "name": "menumbing/outbox",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "php",
+        "hyperf",
+        "outbox",
+        "event-driven"
+    ],
+    "description": "Transactional outbox pattern for Hyperf event stream.",
+    "authors": [
+        {
+            "name": "Aldi Arief",
+            "email": "aldiarief598@gmail.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Menumbing\\Outbox\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "HyperfTest\\": "tests/"
+        }
+    },
+    "require": {
+        "php": ">=8.1",
+        "hyperf/di": "^3.1",
+        "hyperf/event": "^3.1",
+        "hyperf/config": "^3.1",
+        "hyperf/process": "^3.1",
+        "hyperf/db-connection": "^3.1",
+        "ramsey/uuid": "^4.7",
+        "menumbing/contracts": "^1.0",
+        "menumbing/orm": "^1.0",
+        "menumbing/event-stream": "^1.0",
+        "menumbing/serializer": "^1.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "mockery/mockery": "^1.0",
+        "phpstan/phpstan": "^1.0",
+        "phpunit/phpunit": "^10.0",
+        "swoole/ide-helper": "dev-master"
+    },
+    "suggest": {
+        "swow/swow": "Required to create swow components."
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit -c phpunit.xml --colors=always",
+        "analyse": "phpstan analyse --memory-limit 1024M -l 0 ./src",
+        "cs-fix": "php-cs-fixer fix $1"
+    },
+    "extra": {
+        "hyperf": {
+            "config": "Menumbing\\Outbox\\ConfigProvider"
+        },
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
+    }
+}

--- a/outbox/phpunit.xml
+++ b/outbox/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="tests/bootstrap.php"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+>
+    <testsuite name="Testsuite">
+        <directory>./tests/</directory>
+    </testsuite>
+</phpunit>

--- a/outbox/publish/migrations/2024_01_01_000000_create_outbox_messages_table.php
+++ b/outbox/publish/migrations/2024_01_01_000000_create_outbox_messages_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Hyperf\Database\Migrations\Migration;
+use Hyperf\Database\Schema\Blueprint;
+use Hyperf\Database\Schema\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('outbox_messages', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('stream', 100);
+            $table->string('type', 100);
+            $table->json('payload');
+            $table->string('status', 20)->default('pending');
+            $table->unsignedInteger('retry_count')->default(0);
+            $table->text('last_error')->nullable();
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamps();
+
+            // Index for worker polling: WHERE status IN (...) ORDER BY created_at.
+            $table->index(['status', 'created_at']);
+            // Index for querying by stream and event type (monitoring, filtering).
+            $table->index(['stream', 'type']);
+            // Index for pruning: DELETE WHERE status = 'sent' AND sent_at < ?.
+            $table->index(['status', 'sent_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('outbox_messages');
+    }
+};

--- a/outbox/publish/outbox.php
+++ b/outbox/publish/outbox.php
@@ -1,0 +1,71 @@
+<?php
+
+use Menumbing\Outbox\Handler\OutboxProduceEventHandler;
+use Menumbing\Outbox\Storage\DatabaseOutboxStorage;
+
+/**
+ * Configuration for the transactional outbox pattern.
+ *
+ * When enabled, events annotated with #[ProducedEvent] are stored in an
+ * outbox database table (within the active DB transaction) instead of
+ * being published directly to the stream. A background worker process
+ * then relays the stored messages to the actual stream driver.
+ *
+ * This guarantees atomicity: if the DB transaction rolls back, no event
+ * is published; if it commits, the event will eventually be delivered.
+ */
+return [
+
+    /**
+     * The produce handler class used by event-stream's RegisterProducers.
+     *
+     * This value is read by Menumbing\EventStream\Listener\RegisterProducers
+     * (which checks outbox.produce_handler first, then falls back to
+     * event_stream.produce_handler, then to the default ProduceEventHandler).
+     *
+     * Set to OutboxProduceEventHandler::class to route event publishing
+     * through the outbox. Remove or set to ProduceEventHandler::class to
+     * disable the outbox and publish directly to the stream.
+     */
+    'produce_handler' => OutboxProduceEventHandler::class,
+
+    /**
+     * Outbox storage configuration.
+     *
+     * The storage is responsible for persisting and retrieving outbox
+     * messages. The default implementation uses the database connection.
+     */
+    'storage' => [
+        'class'      => DatabaseOutboxStorage::class,
+        'connection' => 'default',
+        'table'      => 'outbox_messages',
+    ],
+
+    /**
+     * Worker (relay) process configuration.
+     *
+     * The worker polls the outbox storage for pending messages and
+     * relays them to the actual event stream driver.
+     */
+    'worker' => [
+        'enabled'        => true,
+        'nums'           => 1,
+        'batch_size'     => 100,
+        'interval'       => 2,
+        'max_retries'    => 5,
+        'retry_after'    => 60,
+    ],
+
+    /**
+     * Pruning configuration.
+     *
+     * Sent messages are retained for auditing but should be pruned
+     * periodically to prevent unbounded table growth. Run the
+     * `outbox:prune` command via cron to clean up old messages.
+     *
+     *   0 3 * * * php bin/hyperf.php outbox:prune
+     */
+    'prune' => [
+        'retention_days' => 7,
+    ],
+];

--- a/outbox/src/Command/PruneOutboxCommand.php
+++ b/outbox/src/Command/PruneOutboxCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Command;
+
+use Hyperf\Command\Annotation\Command;
+use Hyperf\Command\Command as HyperfCommand;
+use Hyperf\Contract\ConfigInterface;
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Prunes sent outbox messages older than the configured retention period.
+ *
+ * Intended to be run via cron:
+ *   0 3 * * * php bin/hyperf.php outbox:prune
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+#[Command]
+class PruneOutboxCommand extends HyperfCommand
+{
+    protected ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        parent::__construct('outbox:prune');
+    }
+
+    public function handle(): void
+    {
+        $config = $this->container->get(ConfigInterface::class);
+
+        $retentionDays = (int) ($this->input->getOption('days')
+            ?? $config->get('outbox.prune.retention_days', 7));
+
+        $storage = $this->container->get(OutboxStorageInterface::class);
+
+        $deleted = $storage->prune($retentionDays);
+
+        $this->info(sprintf('Pruned %d sent messages older than %d days.', $deleted, $retentionDays));
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Delete sent outbox messages older than the retention period.');
+        $this->addOption('days', 'd', InputOption::VALUE_OPTIONAL, 'Number of days to retain sent messages.', null);
+    }
+}

--- a/outbox/src/ConfigProvider.php
+++ b/outbox/src/ConfigProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox;
+
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Menumbing\Outbox\Command\PruneOutboxCommand;
+use Menumbing\Outbox\Listener\RegisterOutboxWorker;
+use Menumbing\Outbox\Storage\OutboxStorageFactory;
+
+class ConfigProvider
+{
+    public function __invoke(): array
+    {
+        return [
+            'dependencies' => [
+                OutboxStorageInterface::class => OutboxStorageFactory::class,
+            ],
+            'listeners' => [
+                RegisterOutboxWorker::class => 99,
+            ],
+            'commands' => [
+                PruneOutboxCommand::class,
+            ],
+            'annotations' => [
+                'scan' => [
+                    'paths' => [
+                        __DIR__,
+                    ],
+                ],
+            ],
+            'publish' => [
+                [
+                    'id' => 'config',
+                    'description' => 'The config for outbox.',
+                    'source' => __DIR__ . '/../publish/outbox.php',
+                    'destination' => BASE_PATH . '/config/autoload/outbox.php',
+                ],
+                [
+                    'id' => 'migration',
+                    'description' => 'The migration for outbox messages table.',
+                    'source' => __DIR__ . '/../publish/migrations/2024_01_01_000000_create_outbox_messages_table.php',
+                    'destination' => BASE_PATH . '/migrations/2024_01_01_000000_create_outbox_messages_table.php',
+                ],
+            ],
+        ];
+    }
+}

--- a/outbox/src/Event/OutboxDeadLettered.php
+++ b/outbox/src/Event/OutboxDeadLettered.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Event;
+
+use Menumbing\Contract\Outbox\OutboxRecord;
+use Throwable;
+
+/**
+ * Dispatched when an outbox message has exceeded the maximum retry
+ * count and will no longer be retried.
+ *
+ * The message is now in DEAD_LETTER status and requires manual
+ * intervention to re-process or discard.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+final class OutboxDeadLettered
+{
+    public function __construct(
+        public readonly OutboxRecord $record,
+        public readonly Throwable $throwable,
+    ) {
+    }
+}

--- a/outbox/src/Event/OutboxRelayFailed.php
+++ b/outbox/src/Event/OutboxRelayFailed.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Event;
+
+use Menumbing\Contract\Outbox\OutboxRecord;
+use Throwable;
+
+/**
+ * Dispatched when relaying an outbox message to the stream failed,
+ * but the message has not yet exceeded the maximum retry count.
+ *
+ * The message will be retried after the configured retry delay.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+final class OutboxRelayFailed
+{
+    public function __construct(
+        public readonly OutboxRecord $record,
+        public readonly Throwable $throwable,
+    ) {
+    }
+}

--- a/outbox/src/Event/OutboxRelayed.php
+++ b/outbox/src/Event/OutboxRelayed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Event;
+
+use Menumbing\Contract\Outbox\OutboxRecord;
+
+/**
+ * Dispatched when an outbox message has been successfully relayed
+ * to the event stream.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+final class OutboxRelayed
+{
+    public function __construct(
+        public readonly OutboxRecord $record,
+    ) {
+    }
+}

--- a/outbox/src/Exception/OutboxException.php
+++ b/outbox/src/Exception/OutboxException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Exception;
+
+use RuntimeException;
+
+/**
+ * Base exception for outbox-related errors.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class OutboxException extends RuntimeException
+{
+}

--- a/outbox/src/Handler/OutboxProduceEventHandler.php
+++ b/outbox/src/Handler/OutboxProduceEventHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Handler;
+
+use Hyperf\Di\Annotation\Inject;
+use Menumbing\Contract\EventStream\StreamMessage;
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Menumbing\EventStream\Event\AfterProduce;
+use Menumbing\EventStream\Event\BeforeProduce;
+use Menumbing\EventStream\Event\ProduceFailed;
+use Menumbing\EventStream\Handler\ProduceEventHandler;
+
+/**
+ * Replaces {@see ProduceEventHandler} to route event publishing through
+ * the outbox storage instead of publishing directly to the stream.
+ *
+ * When configured via `event_stream.produce_handler`, this handler is
+ * instantiated by {@see \Menumbing\EventStream\Listener\RegisterProducers}
+ * and receives the {@see OutboxStorageInterface} via DI injection.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class OutboxProduceEventHandler extends ProduceEventHandler
+{
+    #[Inject]
+    protected OutboxStorageInterface $outboxStorage;
+
+    protected function produce(StreamMessage $message): void
+    {
+        $startTime = microtime(true);
+
+        try {
+            $this->dispatcher->dispatch(new BeforeProduce(
+                $message,
+                $this->driver,
+                $this->annotation->driver,
+                $startTime
+            ));
+
+            // Store to the outbox table instead of publishing directly to the stream.
+            // This INSERT runs within the current database transaction, ensuring
+            // atomicity with the business data.
+            $this->outboxStorage->store($message);
+
+            $this->dispatcher->dispatch(new AfterProduce(
+                $message,
+                $this->driver,
+                $this->annotation->driver,
+                $startTime,
+                microtime(true)
+            ));
+        } catch (\Throwable $e) {
+            $this->dispatcher->dispatch(new ProduceFailed(
+                $e,
+                $message,
+                $this->driver,
+                $this->annotation->driver,
+                $startTime,
+                microtime(true)
+            ));
+
+            throw $e;
+        }
+    }
+}

--- a/outbox/src/Listener/RegisterOutboxWorker.php
+++ b/outbox/src/Listener/RegisterOutboxWorker.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Listener;
+
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Event\Contract\ListenerInterface;
+use Hyperf\Framework\Event\BeforeMainServerStart;
+use Hyperf\Process\ProcessManager;
+use Hyperf\Server\Event\MainCoroutineServerStart;
+use Menumbing\Outbox\Process\OutboxRelayProcess;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Registers the outbox relay worker process on server start.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+final class RegisterOutboxWorker implements ListenerInterface
+{
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
+    public function listen(): array
+    {
+        return [
+            BeforeMainServerStart::class,
+            MainCoroutineServerStart::class,
+        ];
+    }
+
+    public function process(object $event): void
+    {
+        $config = $this->container->get(ConfigInterface::class);
+
+        if (!$config->get('outbox.worker.enabled', true)) {
+            return;
+        }
+
+        $process = $this->container->get(OutboxRelayProcess::class);
+        $process->name = 'outbox-relay';
+        $process->nums = $config->get('outbox.worker.nums', 1);
+
+        ProcessManager::register($process);
+    }
+}

--- a/outbox/src/Model/OutboxMessage.php
+++ b/outbox/src/Model/OutboxMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Model;
+
+use Menumbing\Orm\Model;
+
+/**
+ * Eloquent model for the outbox_messages table.
+ *
+ * This model is provided primarily for querying and monitoring purposes.
+ * The {@see \Menumbing\Outbox\Storage\DatabaseOutboxStorage} uses the
+ * query builder directly to ensure it participates in the active
+ * database transaction.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class OutboxMessage extends Model
+{
+    protected ?string $table = 'outbox_messages';
+
+    public bool $incrementing = false;
+
+    protected string $keyType = 'string';
+
+    protected array $fillable = [
+        'id',
+        'stream',
+        'type',
+        'payload',
+        'status',
+        'retry_count',
+        'last_error',
+        'sent_at',
+        'failed_at',
+    ];
+
+    protected array $casts = [
+        'payload' => 'json',
+        'retry_count' => 'integer',
+        'sent_at' => 'datetime',
+        'failed_at' => 'datetime',
+    ];
+}

--- a/outbox/src/Process/OutboxRelayProcess.php
+++ b/outbox/src/Process/OutboxRelayProcess.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Process;
+
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\CoordinatorManager;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Process\AbstractProcess;
+use Hyperf\Process\ProcessManager;
+use Menumbing\Contract\EventStream\StreamInterface;
+use Menumbing\Contract\Outbox\OutboxRecord;
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Menumbing\Outbox\Event\OutboxDeadLettered;
+use Menumbing\Outbox\Event\OutboxRelayed;
+use Menumbing\Outbox\Event\OutboxRelayFailed;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Background worker process that relays outbox messages to the
+ * actual event stream driver (Redis/Kafka).
+ *
+ * Each polling cycle runs within a storage transaction:
+ *   1. SELECT ... FOR UPDATE SKIP LOCKED — lock pending rows
+ *   2. Publish each message to the stream
+ *   3. Mark as SENT or FAILED (within the same transaction)
+ *   4. COMMIT — release locks
+ *
+ * The worker sleeps for the configured sleep_interval between cycles
+ * to avoid constantly querying the database when there are no messages.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class OutboxRelayProcess extends AbstractProcess
+{
+    public string $name = 'outbox-relay';
+
+    protected int $restartInterval = 1;
+
+    protected OutboxStorageInterface $storage;
+    protected StreamInterface $stream;
+    protected ConfigInterface $config;
+    protected EventDispatcherInterface $dispatcher;
+
+    public function __construct(ContainerInterface $container)
+    {
+        parent::__construct($container);
+
+        $this->storage = $container->get(OutboxStorageInterface::class);
+        $this->stream = $container->get(StreamInterface::class);
+        $this->config = $container->get(ConfigInterface::class);
+        $this->dispatcher = $container->get(EventDispatcherInterface::class);
+    }
+
+    public function handle(): void
+    {
+        $batchSize = $this->config->get('outbox.worker.batch_size', 100);
+        $interval = $this->config->get('outbox.worker.interval', 2);
+        $retryAfter = $this->config->get('outbox.worker.retry_after', 60);
+        $maxRetries = $this->config->get('outbox.worker.max_retries', 5);
+
+        while (ProcessManager::isRunning()) {
+            $this->storage->transaction(function () use ($batchSize, $retryAfter, $maxRetries) {
+                foreach ($this->storage->findPending($batchSize, $retryAfter, forUpdate: true) as $record) {
+                    $this->relay($record, $maxRetries);
+                }
+            });
+
+            if (CoordinatorManager::until(Constants::WORKER_EXIT)->yield($interval)) {
+                break;
+            }
+        }
+    }
+
+    protected function relay(OutboxRecord $record, int $maxRetries): void
+    {
+        try {
+            $this->stream->publish($record->message);
+            $this->storage->markAsSent($record->id);
+
+            $this->dispatcher->dispatch(new OutboxRelayed($record));
+        } catch (\Throwable $e) {
+            $this->storage->markAsFailed($record->id, $e);
+
+            $willBeDeadLettered = $record->retryCount + 1 >= $maxRetries;
+
+            if ($willBeDeadLettered) {
+                $this->dispatcher->dispatch(new OutboxDeadLettered($record, $e));
+            } else {
+                $this->dispatcher->dispatch(new OutboxRelayFailed($record, $e));
+            }
+        }
+    }
+}

--- a/outbox/src/Storage/DatabaseOutboxStorage.php
+++ b/outbox/src/Storage/DatabaseOutboxStorage.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Storage;
+
+use Generator;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Database\ConnectionInterface;
+use Hyperf\Database\ConnectionResolverInterface;
+use Menumbing\Contract\EventStream\StreamMessage;
+use Menumbing\Contract\Outbox\OutboxRecord;
+use Menumbing\Contract\Outbox\OutboxStatus;
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Menumbing\Serializer\Factory\SerializerFactory;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Serializer\Serializer;
+use Throwable;
+
+use function Hyperf\Support\now;
+
+/**
+ * Database-backed outbox storage.
+ *
+ * Uses the same database connection as the ORM so that {@see store()}
+ * participates in the active database transaction, guaranteeing
+ * atomicity between business data and the outbox record.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class DatabaseOutboxStorage implements OutboxStorageInterface
+{
+    protected string $connectionName;
+    protected string $table;
+    protected int $maxRetries;
+
+    protected Serializer $serializer;
+    protected string $serializeFormat;
+
+    public function __construct(
+        ConfigInterface $config,
+        SerializerFactory $serializerFactory,
+        protected ConnectionResolverInterface $connectionResolver,
+    ) {
+        $this->connectionName = $config->get('outbox.storage.connection', 'default');
+        $this->table = $config->get('outbox.storage.table', 'outbox_messages');
+        $this->maxRetries = $config->get('outbox.worker.max_retries', 5);
+
+        $this->serializer = $serializerFactory->get(
+            $config->get('event_stream.serialization.serializer', 'default')
+        );
+        $this->serializeFormat = $config->get('event_stream.serialization.format', 'json');
+    }
+
+    public function store(StreamMessage $message): string
+    {
+        $id = Uuid::uuid4()->toString();
+        $now = now()->toDateTimeString();
+
+        $this->connection()->table($this->table)->insert([
+            'id' => $id,
+            'stream' => $message->stream,
+            'type' => $message->type,
+            'payload' => $this->serializer->serialize($message, $this->serializeFormat),
+            'status' => OutboxStatus::PENDING->value,
+            'retry_count' => 0,
+            'last_error' => null,
+            'sent_at' => null,
+            'failed_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return $id;
+    }
+
+    public function findPending(int $limit, int $retryAfter = 0, bool $forUpdate = false): Generator
+    {
+        $query = $this->connection()->table($this->table)
+            ->whereIn('status', [OutboxStatus::PENDING->value, OutboxStatus::FAILED->value])
+            ->orderBy('created_at', 'asc')
+            ->limit($limit);
+
+        if ($retryAfter > 0) {
+            $cutoff = now()->subSeconds($retryAfter)->toDateTimeString();
+
+            $query->where(function ($q) use ($cutoff) {
+                $q->whereNull('failed_at')
+                    ->orWhere('failed_at', '<=', $cutoff);
+            });
+        }
+
+        if ($forUpdate) {
+            $query->lock('for update skip locked');
+        }
+
+        foreach ($query->get() as $row) {
+            yield $this->toRecord($row);
+        }
+    }
+
+    public function transaction(callable $callback): void
+    {
+        $this->connection()->transaction($callback);
+    }
+
+    public function markAsSent(string $id): void
+    {
+        $now = now()->toDateTimeString();
+
+        $this->connection()->table($this->table)
+            ->where('id', $id)
+            ->update([
+                'status' => OutboxStatus::SENT->value,
+                'sent_at' => $now,
+                'updated_at' => $now,
+            ]);
+    }
+
+    public function markAsFailed(string $id, Throwable $error): void
+    {
+        $record = $this->connection()->table($this->table)->where('id', $id)->first();
+
+        if (!$record) {
+            return;
+        }
+
+        $retryCount = (int) $record->retry_count + 1;
+        $now = now()->toDateTimeString();
+
+        $status = $retryCount >= $this->maxRetries
+            ? OutboxStatus::DEAD_LETTER->value
+            : OutboxStatus::FAILED->value;
+
+        $this->connection()->table($this->table)
+            ->where('id', $id)
+            ->update([
+                'status' => $status,
+                'retry_count' => $retryCount,
+                'last_error' => mb_substr($error->getMessage(), 0, 65535),
+                'failed_at' => $now,
+                'updated_at' => $now,
+            ]);
+    }
+
+    public function countPending(): int
+    {
+        return $this->connection()->table($this->table)
+            ->whereIn('status', [OutboxStatus::PENDING->value, OutboxStatus::FAILED->value])
+            ->count();
+    }
+
+    public function prune(int $retentionDays): int
+    {
+        $cutoff = now()->subDays($retentionDays)->toDateTimeString();
+
+        return $this->connection()->table($this->table)
+            ->where('status', OutboxStatus::SENT->value)
+            ->where('sent_at', '<', $cutoff)
+            ->delete();
+    }
+
+    protected function connection(): ConnectionInterface
+    {
+        return $this->connectionResolver->connection($this->connectionName);
+    }
+
+    protected function toRecord(object|array $row): OutboxRecord
+    {
+        $row = (object) $row;
+
+        $message = $this->serializer->deserialize(
+            $row->payload,
+            StreamMessage::class,
+            $this->serializeFormat
+        );
+
+        return new OutboxRecord(
+            id: $row->id,
+            message: $message,
+            status: OutboxStatus::from($row->status),
+            retryCount: (int) $row->retry_count,
+            lastError: $row->last_error,
+            sentAt: $row->sent_at,
+            failedAt: $row->failed_at,
+        );
+    }
+}

--- a/outbox/src/Storage/OutboxStorageFactory.php
+++ b/outbox/src/Storage/OutboxStorageFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menumbing\Outbox\Storage;
+
+use Hyperf\Contract\ConfigInterface;
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Factory that resolves the configured outbox storage implementation.
+ *
+ * @author  Aldi Arief <aldiarief598@gmail.com>
+ */
+class OutboxStorageFactory
+{
+    public function __construct(
+        private ContainerInterface $container,
+    ) {
+    }
+
+    public function __invoke(): OutboxStorageInterface
+    {
+        $config = $this->container->get(ConfigInterface::class);
+        $class = $config->get('outbox.storage.class', DatabaseOutboxStorage::class);
+
+        return $this->container->get($class);
+    }
+}

--- a/outbox/tests/Cases/AbstractTestCase.php
+++ b/outbox/tests/Cases/AbstractTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Cases;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTestCase extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+}

--- a/outbox/tests/Cases/DatabaseOutboxStorageTest.php
+++ b/outbox/tests/Cases/DatabaseOutboxStorageTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Cases;
+
+use Hyperf\Collection\Collection;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Database\ConnectionInterface;
+use Hyperf\Database\ConnectionResolverInterface;
+use Hyperf\Database\Query\Builder;
+use Menumbing\Contract\EventStream\StreamMessage;
+use Menumbing\Contract\Outbox\OutboxStatus;
+use Menumbing\Outbox\Storage\DatabaseOutboxStorage;
+use Menumbing\Serializer\Factory\SerializerFactory;
+use Mockery;
+use Mockery\MockInterface;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class DatabaseOutboxStorageTest extends AbstractTestCase
+{
+    private MockInterface $config;
+    private MockInterface $serializerFactory;
+    private Serializer $serializer;
+    private MockInterface $connectionResolver;
+    private MockInterface $connection;
+    private DatabaseOutboxStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->config = Mockery::mock(ConfigInterface::class);
+        $this->config->shouldReceive('get')->with('outbox.storage.connection', 'default')->andReturn('default');
+        $this->config->shouldReceive('get')->with('outbox.storage.table', 'outbox_messages')->andReturn('outbox_messages');
+        $this->config->shouldReceive('get')->with('outbox.worker.max_retries', 5)->andReturn(3);
+        $this->config->shouldReceive('get')->with('event_stream.serialization.serializer', 'default')->andReturn('default');
+        $this->config->shouldReceive('get')->with('event_stream.serialization.format', 'json')->andReturn('json');
+
+        $this->serializer = new Serializer(
+            [new ObjectNormalizer()],
+            [new JsonEncoder()],
+        );
+        $this->serializerFactory = Mockery::mock(SerializerFactory::class);
+        $this->serializerFactory->shouldReceive('get')->with('default')->andReturn($this->serializer);
+
+        $this->connection = Mockery::mock(ConnectionInterface::class);
+        $this->connectionResolver = Mockery::mock(ConnectionResolverInterface::class);
+        $this->connectionResolver->shouldReceive('connection')->with('default')->andReturn($this->connection);
+
+        $this->storage = new DatabaseOutboxStorage(
+            $this->config,
+            $this->serializerFactory,
+            $this->connectionResolver,
+        );
+    }
+
+    public function test_store_inserts_correct_fields(): void
+    {
+        $message = new StreamMessage('user-events', 'user.created', ['id' => 1]);
+
+        $builder = Mockery::mock(Builder::class);
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($builder);
+
+        $builder->shouldReceive('insert')->with(Mockery::on(function (array $data): bool {
+            return $data['stream'] === 'user-events'
+                && $data['type'] === 'user.created'
+                && is_string($data['payload'])
+                && str_contains($data['payload'], 'user-events')
+                && $data['status'] === 'pending'
+                && $data['retry_count'] === 0
+                && $data['last_error'] === null
+                && $data['sent_at'] === null
+                && $data['failed_at'] === null
+                && isset($data['id'])
+                && isset($data['created_at'])
+                && isset($data['updated_at']);
+        }))->once();
+
+        $id = $this->storage->store($message);
+
+        $this->assertNotEmpty($id);
+    }
+
+    public function test_find_pending_with_for_update_applies_lock_clause(): void
+    {
+        $builder = $this->expectFindPendingQuery([]);
+
+        $builder->shouldReceive('lock')->with('for update skip locked')->once()->andReturnSelf();
+
+        $records = iterator_to_array($this->storage->findPending(100, 0, true));
+
+        $this->assertEmpty($records);
+    }
+
+    public function test_find_pending_without_for_update_does_not_lock(): void
+    {
+        $builder = $this->expectFindPendingQuery([]);
+
+        $builder->shouldNotReceive('lock');
+
+        $records = iterator_to_array($this->storage->findPending(100, 0, false));
+
+        $this->assertEmpty($records);
+    }
+
+    public function test_find_pending_returns_pending_and_failed_messages(): void
+    {
+        $message1 = new StreamMessage('s1', 't1', null);
+        $message2 = new StreamMessage('s2', 't2', null);
+
+        $row1 = (object) [
+            'id' => 'uuid-1',
+            'payload' => $this->serializer->serialize($message1, 'json'),
+            'status' => 'pending',
+            'retry_count' => 0,
+            'last_error' => null,
+            'sent_at' => null,
+            'failed_at' => null,
+        ];
+        $row2 = (object) [
+            'id' => 'uuid-2',
+            'payload' => $this->serializer->serialize($message2, 'json'),
+            'status' => 'failed',
+            'retry_count' => 1,
+            'last_error' => 'timeout',
+            'sent_at' => null,
+            'failed_at' => '2024-01-01 00:00:00',
+        ];
+
+        $this->expectFindPendingQuery([$row1, $row2]);
+
+        $records = iterator_to_array($this->storage->findPending(100, 0, false));
+
+        $this->assertCount(2, $records);
+        $this->assertSame('uuid-1', $records[0]->id);
+        $this->assertSame('s1', $records[0]->message->stream);
+        $this->assertSame('t1', $records[0]->message->type);
+        $this->assertSame(OutboxStatus::PENDING, $records[0]->status);
+        $this->assertSame('uuid-2', $records[1]->id);
+        $this->assertSame('s2', $records[1]->message->stream);
+        $this->assertSame(OutboxStatus::FAILED, $records[1]->status);
+        $this->assertSame(1, $records[1]->retryCount);
+        $this->assertSame('timeout', $records[1]->lastError);
+    }
+
+    public function test_find_pending_applies_retry_after_filter(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($builder);
+
+        $builder->shouldReceive('whereIn')->once()->andReturnSelf();
+        $builder->shouldReceive('orderBy')->once()->andReturnSelf();
+        $builder->shouldReceive('limit')->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with(Mockery::type('Closure'))->once()->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn(Collection::make([]));
+
+        $records = iterator_to_array($this->storage->findPending(100, 60, false));
+
+        $this->assertEmpty($records);
+    }
+
+    public function test_mark_as_sent_updates_status(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($builder);
+
+        $builder->shouldReceive('where')->with('id', 'test-id')->once()->andReturnSelf();
+        $builder->shouldReceive('update')->with(Mockery::on(function (array $data): bool {
+            return $data['status'] === 'sent'
+                && isset($data['sent_at'])
+                && isset($data['updated_at']);
+        }))->once();
+
+        $this->storage->markAsSent('test-id');
+    }
+
+    public function test_mark_as_failed_increments_retry_count(): void
+    {
+        $existingRecord = (object) ['retry_count' => 1];
+
+        $selectBuilder = Mockery::mock(Builder::class);
+        $updateBuilder = Mockery::mock(Builder::class);
+
+        $this->connection->shouldReceive('table')->with('outbox_messages')->twice()
+            ->andReturn($selectBuilder, $updateBuilder);
+
+        $selectBuilder->shouldReceive('where')->with('id', 'test-id')->once()->andReturnSelf();
+        $selectBuilder->shouldReceive('first')->once()->andReturn($existingRecord);
+
+        $updateBuilder->shouldReceive('where')->with('id', 'test-id')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->with(Mockery::on(function (array $data): bool {
+            return $data['status'] === 'failed'
+                && $data['retry_count'] === 2
+                && isset($data['last_error'])
+                && isset($data['failed_at'])
+                && isset($data['updated_at']);
+        }))->once();
+
+        $this->storage->markAsFailed('test-id', new \RuntimeException('Stream down'));
+    }
+
+    public function test_mark_as_failed_transitions_to_dead_letter_after_max_retries(): void
+    {
+        $existingRecord = (object) ['retry_count' => 2];
+
+        $selectBuilder = Mockery::mock(Builder::class);
+        $updateBuilder = Mockery::mock(Builder::class);
+
+        $this->connection->shouldReceive('table')->with('outbox_messages')->twice()
+            ->andReturn($selectBuilder, $updateBuilder);
+
+        $selectBuilder->shouldReceive('where')->with('id', 'test-id')->once()->andReturnSelf();
+        $selectBuilder->shouldReceive('first')->once()->andReturn($existingRecord);
+
+        $updateBuilder->shouldReceive('where')->with('id', 'test-id')->once()->andReturnSelf();
+        $updateBuilder->shouldReceive('update')->with(Mockery::on(function (array $data): bool {
+            return $data['status'] === 'dead_letter'
+                && $data['retry_count'] === 3;
+        }))->once();
+
+        $this->storage->markAsFailed('test-id', new \RuntimeException('Stream down'));
+    }
+
+    public function test_mark_as_failed_does_nothing_when_record_not_found(): void
+    {
+        $selectBuilder = Mockery::mock(Builder::class);
+
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($selectBuilder);
+        $selectBuilder->shouldReceive('where')->with('id', 'missing-id')->once()->andReturnSelf();
+        $selectBuilder->shouldReceive('first')->once()->andReturn(null);
+
+        $this->storage->markAsFailed('missing-id', new \RuntimeException('error'));
+    }
+
+    public function test_transaction_delegates_to_connection(): void
+    {
+        $callbackExecuted = false;
+
+        $this->connection->shouldReceive('transaction')->with(Mockery::on(function ($callback) use (&$callbackExecuted): bool {
+            $callback();
+            return true;
+        }))->once();
+
+        $this->storage->transaction(function () use (&$callbackExecuted): void {
+            $callbackExecuted = true;
+        });
+
+        $this->assertTrue($callbackExecuted);
+    }
+
+    public function test_count_pending_returns_count(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($builder);
+
+        $builder->shouldReceive('whereIn')->once()->andReturnSelf();
+        $builder->shouldReceive('count')->once()->andReturn(42);
+
+        $this->assertSame(42, $this->storage->countPending());
+    }
+
+    public function test_prune_deletes_sent_messages_older_than_retention(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($builder);
+
+        $builder->shouldReceive('where')->with('status', 'sent')->once()->andReturnSelf();
+        $builder->shouldReceive('where')->with('sent_at', '<', Mockery::type('string'))->once()->andReturnSelf();
+        $builder->shouldReceive('delete')->once()->andReturn(15);
+
+        $this->assertSame(15, $this->storage->prune(7));
+    }
+
+    /**
+     * Set up the mock chain for findPending query builder (without retry_after filter).
+     */
+    private function expectFindPendingQuery(array $rows): MockInterface
+    {
+        $builder = Mockery::mock(Builder::class);
+
+        $this->connection->shouldReceive('table')->with('outbox_messages')->once()->andReturn($builder);
+        $builder->shouldReceive('whereIn')->once()->andReturnSelf();
+        $builder->shouldReceive('orderBy')->once()->andReturnSelf();
+        $builder->shouldReceive('limit')->once()->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn(Collection::make($rows));
+
+        return $builder;
+    }
+}

--- a/outbox/tests/Cases/OutboxRelayProcessTest.php
+++ b/outbox/tests/Cases/OutboxRelayProcessTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Cases;
+
+use Hyperf\Contract\ConfigInterface;
+use Mockery;
+use Menumbing\Contract\EventStream\StreamInterface;
+use Menumbing\Contract\EventStream\StreamMessage;
+use Menumbing\Contract\Outbox\OutboxRecord;
+use Menumbing\Contract\Outbox\OutboxStatus;
+use Menumbing\Contract\Outbox\OutboxStorageInterface;
+use Menumbing\Outbox\Event\OutboxDeadLettered;
+use Menumbing\Outbox\Event\OutboxRelayed;
+use Menumbing\Outbox\Event\OutboxRelayFailed;
+use Menumbing\Outbox\Process\OutboxRelayProcess;
+use Mockery\MockInterface;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use RuntimeException;
+
+class OutboxRelayProcessTest extends AbstractTestCase
+{
+    private MockInterface $container;
+    private MockInterface $storage;
+    private MockInterface $stream;
+    private MockInterface $config;
+    private MockInterface $dispatcher;
+    private TestableOutboxRelayProcess $process;
+
+    protected function setUp(): void
+    {
+        $this->storage = Mockery::mock(OutboxStorageInterface::class);
+        $this->stream = Mockery::mock(StreamInterface::class);
+        $this->config = Mockery::mock(ConfigInterface::class);
+        $this->dispatcher = Mockery::mock(EventDispatcherInterface::class);
+
+        $this->container = Mockery::mock(ContainerInterface::class);
+        $this->container->allows()->has(EventDispatcherInterface::class)->andReturns(true);
+        $this->container->allows()->get(OutboxStorageInterface::class)->andReturns($this->storage);
+        $this->container->allows()->get(StreamInterface::class)->andReturns($this->stream);
+        $this->container->allows()->get(ConfigInterface::class)->andReturns($this->config);
+        $this->container->allows()->get(EventDispatcherInterface::class)->andReturns($this->dispatcher);
+
+        $this->process = new TestableOutboxRelayProcess($this->container);
+    }
+
+    public function test_relay_marks_as_sent_on_success(): void
+    {
+        $record = $this->createRecord('uuid-1', OutboxStatus::PENDING, 0);
+
+        $this->stream->expects()->publish($record->message)
+            ->andReturns('stream-id-1');
+
+        $this->storage->expects()->markAsSent('uuid-1');
+
+        $this->dispatcher->expects()->dispatch(Mockery::on(function ($event): bool {
+            return $event instanceof OutboxRelayed
+                && $event->record->id === 'uuid-1';
+        }));
+
+        $this->process->exposeRelay($record, 5);
+    }
+
+    public function test_relay_marks_as_failed_on_exception(): void
+    {
+        $record = $this->createRecord('uuid-2', OutboxStatus::FAILED, 1);
+        $exception = new RuntimeException('Stream unavailable');
+
+        $this->stream->expects()->publish($record->message)
+            ->andThrows($exception);
+
+        $this->storage->expects()->markAsFailed('uuid-2', $exception);
+
+        $this->dispatcher->expects()->dispatch(Mockery::on(function ($event) use ($exception): bool {
+            return $event instanceof OutboxRelayFailed
+                && $event->record->id === 'uuid-2'
+                && $event->throwable === $exception;
+        }));
+
+        $this->process->exposeRelay($record, 5);
+    }
+
+    public function test_relay_dispatches_dead_lettered_after_max_retries(): void
+    {
+        $record = $this->createRecord('uuid-3', OutboxStatus::FAILED, 4);
+        $exception = new RuntimeException('Stream still down');
+
+        $this->stream->expects()->publish($record->message)
+            ->andThrows($exception);
+
+        $this->storage->expects()->markAsFailed('uuid-3', $exception);
+
+        $this->dispatcher->expects()->dispatch(Mockery::on(function ($event) use ($exception): bool {
+            return $event instanceof OutboxDeadLettered
+                && $event->record->id === 'uuid-3'
+                && $event->throwable === $exception;
+        }));
+
+        // retryCount (4) + 1 = 5, which equals maxRetries (5) → dead-lettered
+        $this->process->exposeRelay($record, 5);
+    }
+
+    public function test_relay_does_not_dead_letter_when_below_max_retries(): void
+    {
+        $record = $this->createRecord('uuid-4', OutboxStatus::FAILED, 3);
+        $exception = new RuntimeException('Timeout');
+
+        $this->stream->expects()->publish($record->message)
+            ->andThrows($exception);
+
+        $this->storage->expects()->markAsFailed('uuid-4', $exception);
+
+        // Should dispatch OutboxRelayFailed, NOT OutboxDeadLettered
+        $this->dispatcher->expects()->dispatch(Mockery::on(function ($event): bool {
+            return $event instanceof OutboxRelayFailed;
+        }));
+
+        $this->dispatcher->shouldNotReceive('dispatch')
+            ->with(Mockery::on(fn ($e) => $e instanceof OutboxDeadLettered));
+
+        // retryCount (3) + 1 = 4, which is less than maxRetries (5) → not dead-lettered
+        $this->process->exposeRelay($record, 5);
+    }
+
+    private function createRecord(
+        string $id,
+        OutboxStatus $status,
+        int $retryCount,
+    ): OutboxRecord {
+        return new OutboxRecord(
+            id: $id,
+            message: new StreamMessage('test-stream', 'test.event', ['key' => 'value']),
+            status: $status,
+            retryCount: $retryCount,
+        );
+    }
+}
+
+/**
+ * Test subclass that exposes the protected relay() method.
+ */
+class TestableOutboxRelayProcess extends OutboxRelayProcess
+{
+    public function exposeRelay(OutboxRecord $record, int $maxRetries): void
+    {
+        $this->relay($record, $maxRetries);
+    }
+}

--- a/outbox/tests/bootstrap.php
+++ b/outbox/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php';


### PR DESCRIPTION
# feat: outbox pattern

## **Summary**

Implements the transactional outbox pattern as a standalone package (`menumbing/outbox`). Events annotated with `#[ProducedEvent]` are stored in an `outbox_messages` database table within the active DB transaction instead of being published directly to the stream. A background worker process relays stored messages to the actual stream driver (Redis/Kafka) with at-least-once delivery semantics and automatic retry with dead-lettering.

This solves the dual-write problem: if the DB transaction rolls back, no event is published; if it commits, the event will eventually be delivered.

## **What's Included**

### **Core**

- **`OutboxProduceEventHandler`** — replaces the default `ProduceEventHandler`; intercepts `#[ProducedEvent]` events and stores them to the outbox table instead of publishing directly
- **`DatabaseOutboxStorage`** — persists/retrieves outbox messages using the ORM's database connection; participates in the active transaction
- **`OutboxRelayProcess`** — background Hyperf process that polls for pending messages and relays them to the stream using `FOR UPDATE SKIP LOCKED` for safe concurrent processing
- **`OutboxMessage` model** — Eloquent-style model for querying/monitoring the outbox table

### **Lifecycle & Events**

- **Message states**: `pending` → `sent` / `failed` → `dead_letter`
- **`OutboxRelayed`** — dispatched on successful relay
- **`OutboxRelayFailed`** — dispatched on relay failure (will be retried)
- **`OutboxDeadLettered`** — dispatched when max retries exceeded

### **Pruning**

- **`outbox:prune` command** — deletes sent messages older than the configured retention period; intended for cron scheduling per project
- Config: `outbox.prune.retention_days` (default: 7)

### **Database**

- Migration with 3 composite indexes optimized for the actual query patterns:
    - `(status, created_at)` — worker polling + `ORDER BY`
    - `(stream, type)` — monitoring/filtering
    - `(status, sent_at)` — pruning

### **Tests**

- 16 tests, 79 assertions covering storage operations and relay process lifecycle

## **Event-Stream Integration**

This PR includes a small, backward-compatible change to `menumbing/event-stream`'s `RegisterProducers`:

1. **`Container::make()` instead of `new`** — resolves handler classes through the DI container so that subclasses using `#[Inject]` (e.g. `OutboxProduceEventHandler`) are properly wired. No effect on the default `ProduceEventHandler`.
2. **Config fallback** — handler class resolved as: `outbox.produce_handler` → `event_stream.produce_handler` → `ProduceEventHandler::class`

## **Files Changed**

**New package (`outbox/`)**

- `src/Command/PruneOutboxCommand.php`
- `src/ConfigProvider.php`
- `src/Event/OutboxDeadLettered.php`, `OutboxRelayFailed.php`, `OutboxRelayed.php`
- `src/Exception/OutboxException.php`
- `src/Handler/OutboxProduceEventHandler.php`
- `src/Listener/RegisterOutboxWorker.php`
- `src/Model/OutboxMessage.php`
- `src/Process/OutboxRelayProcess.php`
- `src/Storage/DatabaseOutboxStorage.php`, `OutboxStorageFactory.php`
- `tests/Cases/DatabaseOutboxStorageTest.php`, `OutboxRelayProcessTest.php`, `AbstractTestCase.php`, `bootstrap.php`
- `publish/outbox.php`, `publish/migrations/...`
- `phpunit.xml`, `composer.json`, `README.md`

**Contract (`contract/`)**

- `Outbox/OutboxStorageInterface.php` — storage contract with `store`, `findPending`, `markAsSent`, `markAsFailed`, `countPending`, `prune`
- `Outbox/OutboxRecord.php` — immutable DTO for outbox records
- `Outbox/OutboxStatus.php` — enum: `pending`, `failed`, `sent`, `dead_letter`

**Event-stream (`event-stream/`)**

- `src/Listener/RegisterProducers.php` — `make()` + config fallback (backward-compatible)

## **Post-Merge Steps**

```bash
# Publish config + migration
php bin/hyperf.php vendor:publish menumbing/outbox

# Run migration
php bin/hyperf.php migrate

# (Optional) Set up cron for pruning
0 3 * * * cd /path/to/project && php bin/hyperf.php outbox:prune
```